### PR TITLE
Add therubyracer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,5 @@ gem 'sass-rails', '~> 4.0.0'
 gem 'uglifier', '>= 1.3.0'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
+gem 'therubyracer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     hike (1.2.3)
     http_parser.rb (0.5.3)
     i18n (0.6.9)
+    libv8 (3.16.14.3)
     logjam_agent (0.9.4)
       activesupport
       time_bandits (>= 0.6.0)
@@ -109,6 +110,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.0)
+    ref (1.0.5)
     sass (3.2.10)
     sass-rails (4.0.0)
       railties (>= 4.0.0.beta, < 5.0)
@@ -123,6 +125,9 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    therubyracer (0.12.0)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.18.1)
     thread_safe (0.1.3)
       atomic
@@ -169,6 +174,7 @@ DEPENDENCIES
   rails (~> 4.0.2)
   rake (~> 10.1.0)
   sass-rails (~> 4.0.0)
+  therubyracer
   time_bandits (~> 0.6.0)
   turn
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Hi Stefan,

when you deploy logjam_app in production mode and try to run `RAILS_ENV=production bundle exec rake assets:precompile`, it's not working out of the box. It's missing a javascript runtime to do that. What do you think about just shipping the app with `therubyracer` enabled?

Cheers,
plu
